### PR TITLE
Default to replacing all instances of placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,4 @@ package_file     | string | The JSON containing file from which we should read t
 version_property | string | The name of the property that holds the version text within the JSON file     | 'version'
 prepend          | string | A string to prepend to the outputted version text                             | 'v'
 append           | string | A string to append to the outputted version text                              | ''
-replace          | string | The placeholder text to be replaced with the version text in the source files | '%%GULP_INJECT_VERSION%%'
+replace          | string | The text or pattern to be sought out and replaced with the version text in the source files | /%%GULP_INJECT_VERSION%%/g

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var fs = require('fs'),
         version_property: 'version',
         prepend: 'v',
         append: '',
-        replace: '%%GULP_INJECT_VERSION%%'
+        replace: /%%GULP_INJECT_VERSION%%/g
     };
 
 module.exports = function (opts) {


### PR DESCRIPTION
As a fix to issue #7 I've replaced the default `replace` option with a regex that searches globally.

The only backwards compatibility issues with this change would be if a developer had the placeholder text existing in multiple places within a file, and _really_ only wanted the first replaced. This would be an edge case, IMO, and could be easily corrected by the developer by providing her own non-global `replace` option when invoking.
