### PR TITLE
removes gulp-util dependency and updates through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs'),
     through = require('through2'),
-    gutil = require('gulp-util'),
+    PluginError = require('plugin-error'),
     plugin_name = 'gulp-inject-version',
     defaults = {
         package_file: 'package.json',
@@ -21,12 +21,12 @@ module.exports = function (opts) {
             }
 
             if (file.isStream()) {
-                return callback(new gutil.PluginError(plugin_name, 'doesn\'t support Streams'));
+                return callback(new PluginError(plugin_name, 'doesn\'t support Streams'));
             }
 
             fs.readFile(opts.package_file, 'utf8', function (err, data) {
                 if (err) {
-                    return callback(new gutil.PluginError(plugin_name, opts.package_file + ' could not be read.\n\t' + err.toString()));
+                    return callback(new PluginError(plugin_name, opts.package_file + ' could not be read.\n\t' + err.toString()));
                 } else {
                     try {
                         package_obj = JSON.parse(data);
@@ -41,10 +41,10 @@ module.exports = function (opts) {
                             file.contents = new Buffer(file.contents.toString().replace(opts.replace, version_text));
                             callback(null, file);
                         } else {
-                            return callback(new gutil.PluginError(plugin_name, opts.version_property + ' not found in package data object.'));
+                            return callback(new PluginError(plugin_name, opts.version_property + ' not found in package data object.'));
                         }
                     } catch (ignore) {
-                        return callback(new gutil.PluginError(plugin_name, opts.package_file + ' not valid JSON'));
+                        return callback(new PluginError(plugin_name, opts.package_file + ' not valid JSON'));
                     }
               }
             });

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "gulp-inject-version",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Inject a package version into text based files",
   "main": "index.js",
   "dependencies": {
-    "gulp-util": "^3.0.3",
-    "through2": "^0.6.1"
+    "plugin-error": "^1.0.1",
+    "through2": "^2.0.5"
   },
   "devDependencies": {
-    "gulp": "^3.8.8"
+    "gulp": "^3.8.11"
   },
   "engines": {
     "node": ">= 0.10"


### PR DESCRIPTION
As [gulp-util is deprecated](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) and triggers a warning when installing in npm please replace it with a recommended package.